### PR TITLE
add 'scanned' designation for AI network graph

### DIFF
--- a/default/python/AI/UniverseStrategyAI.py
+++ b/default/python/AI/UniverseStrategyAI.py
@@ -39,6 +39,7 @@ class UniverseGraph(Graph):
         self.reset()  # reset to an empty graph
 
         universe = fo.getUniverse()
+        empire_id = fo.empireID()
         for system_id in universe.systemIDs:
             system = universe.getSystem(system_id)
             if not system:
@@ -61,6 +62,8 @@ class UniverseGraph(Graph):
                 node_dict['explored'] = True
             if system_id == foAI.foAIstate._AIstate__origin_home_system_id:
                 node_dict['home_system'] = True
+            if universe.getVisibilityTurnsMap(system_id, empire_id).get(fo.visibility.partial, -9999) > -1:
+                node_dict['scanned'] = True
 
             self.add_node(system_id, attr_dict=node_dict)
 

--- a/default/python/common/charting/plot_dumped_graph.py
+++ b/default/python/common/charting/plot_dumped_graph.py
@@ -59,10 +59,11 @@ def parse_file(file_name):
 color_map = OrderedDict([('Home', '#00008B'),
                          ('Own Interior Colony', '#4169E1'),
                          ('Own Border Colony', '#3ADF00'),
-                         ('Unexplored', '#808080'),
                          ('Unowned Border System', '#FFFF00'),
                          ('Expansion System', '#F2F5A9'),
-                         ('Misc', '#000000'),
+                         ('Misc', '#B0B0B0'),
+                         ('Scanned', '#808080'),
+                         ('Unexplored', '#000000'),
                          ('Offensive System', '#DC143C'),
                          ('Other Enemy System', '#F78181'),
                          ])
@@ -97,7 +98,10 @@ def draw(g, empire_id):
             return color_map['Expansion System']
 
         if not data_dict.get('explored', False):
-            return color_map['Unexplored']
+            if data_dict.get('scanned', False):
+                return color_map['Scanned']
+            else:
+                return color_map['Unexplored']
 
         return color_map['Misc']
 


### PR DESCRIPTION
  - for systems seen with partial vis but not physically explored
  - leaves the unexplored category meaning neither scanned nor explored

This last part is partly just an aesthetic adjustment, but to my eye makes them more readable:
adjust colors for misc and unexplored, so we now have
  - misc -- light grey
  - scanned -- medium grey
  - unexplored -- black