### PR TITLE
graph bugfix and tweak

### DIFF
--- a/default/python/AI/UniverseStrategyAI.py
+++ b/default/python/AI/UniverseStrategyAI.py
@@ -4,7 +4,7 @@ from functools import wraps
 
 import freeOrionAIInterface as fo
 import FreeOrionAI as foAI
-from graph_interface import Graph
+from graph_interface import Graph, NoPathException
 
 from common.configure_logging import convenience_function_references_for_logger
 (debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
@@ -229,6 +229,9 @@ def __find_defensive_positions_min_cut(weight_owned, weight_enemy):
     try:
         # note that the finally-block is executed even if we exit the function using a return statement
         return __universe_graph.minimum_st_node_cut(s, t, weight_fnc)
+    except NoPathException as e:
+        warn("If empire has not been eliminated, this is an error: " + str(e))
+        return set()
     except Exception as e:
         error(e, exc_info=1)
         return set()

--- a/default/python/AI/UniverseStrategyAI.py
+++ b/default/python/AI/UniverseStrategyAI.py
@@ -131,7 +131,7 @@ def __alters_and_restores_universe_graph(function):
         """This exception is to be thrown when a function did alter the universe graph when it was not allowed to."""
         def __init__(self, fnc_name=""):
             self.message = "Function %s broke the UniverseGraph instance" % fnc_name
-            error(self.message)
+            error(self.message, exc_info=1)
 
     @wraps(function)
     def wrapper(*args, **kwargs):
@@ -230,7 +230,7 @@ def __find_defensive_positions_min_cut(weight_owned, weight_enemy):
         # note that the finally-block is executed even if we exit the function using a return statement
         return __universe_graph.minimum_st_node_cut(s, t, weight_fnc)
     except Exception as e:
-        error(e)
+        error(e, exc_info=1)
         return set()
     finally:
         # remove the previously added nodes and edges
@@ -290,7 +290,7 @@ def __find_inner_systems():
                 inner_systems.update(subnodelist)
         return inner_systems
     except Exception as e:
-        error(e)
+        error(e, exc_info=1)
         return set()
     finally:
         # restore the previously added nodes and edges

--- a/default/python/AI/graph_interface/NetworkXInterface.py
+++ b/default/python/AI/graph_interface/NetworkXInterface.py
@@ -16,6 +16,7 @@ import networkx as nx
 from networkx.algorithms.connectivity import minimum_st_node_cut
 from networkx.algorithms.components import connected_components
 
+NoPathException = nx.NetworkXNoPath
 
 class NxGraphInterface(GraphInterface):
     """NetworkX implementation of the GraphInterface"""

--- a/default/python/AI/graph_interface/__init__.py
+++ b/default/python/AI/graph_interface/__init__.py
@@ -1,1 +1,1 @@
-from NetworkXInterface import NxGraphInterface as Graph
+from NetworkXInterface import NoPathException, NxGraphInterface as Graph


### PR DESCRIPTION
when an AI empire gets eliminated, it was causing min-cut NoPath error spam.  The first commit just augments the general error reporting with traceback info, and the second commit changes the logging for this particular exception into a warning to stop the generally unwarranted message window spam. 

The third commit is just a tweak to add a title to the dump graphs, identifying which AI the graph is for.